### PR TITLE
Actor.action() is run before Actor.get_message()

### DIFF
--- a/aktos_dcs/gevent_actor.py
+++ b/aktos_dcs/gevent_actor.py
@@ -67,9 +67,8 @@ class ActorBase(gevent.Greenlet):
                     if callable(handler_func):
                         gevent.spawn(handler_func, msg)
 
-        a = gevent.spawn(get_message)
-        b = gevent.spawn(self.action)
-        #gevent.joinall([a, b])
+        gevent.spawn(self.action)
+        gevent.spawn(get_message)
         while True:
             gevent.sleep(1)
 


### PR DESCRIPTION
...so instance variables can be defined in `Actor.action()` as if it is defined in `Actor.__init__()`.